### PR TITLE
Add user_uid to CouchDB auth doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Now to login, simply post your username and password to `http://localhost:3000/a
   "token": "aViSVnaDRFKFfdepdXtiEg",
   "password": "p7l9VCNbTbOVeuvEBhYW_A",
   "user_id": "joesmith",
+  "user_uid": "86801e38-e3f6-49b4-9187-e5116aa1ecea",
   "roles": ["user"],
   "userDBs": {
     "supertest": "http://aViSVnaDRFKFfdepdXtiEg:p7l9VCNbTbOVeuvEBhYW_A@localhost:5984/supertest$joesmith"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Now to login, simply post your username and password to `http://localhost:3000/a
   "token": "aViSVnaDRFKFfdepdXtiEg",
   "password": "p7l9VCNbTbOVeuvEBhYW_A",
   "user_id": "joesmith",
-  "user_uid": "86801e38-e3f6-49b4-9187-e5116aa1ecea",
   "roles": ["user"],
   "userDBs": {
     "supertest": "http://aViSVnaDRFKFfdepdXtiEg:p7l9VCNbTbOVeuvEBhYW_A@localhost:5984/supertest$joesmith"

--- a/src/dbauth/couchdb.ts
+++ b/src/dbauth/couchdb.ts
@@ -29,7 +29,7 @@ export class CouchAdapter implements DBAdapter {
 
   /**
    * stores a CouchDbAuthDoc with the passed information. Expects the `username`
-   * (i.e. `key`) and not the UUID.
+   * (i.e. `key`) and the UUID.
    */
   async storeKey(
     username: string,
@@ -51,7 +51,7 @@ export class CouchAdapter implements DBAdapter {
       _id: userPrefix + key,
       type: 'user',
       name: key,
-      user_uid: hyphenizeUUID(user_uid),
+      user_uid: user_uid,
       user_id: username,
       expires: expires,
       roles: roles,

--- a/src/dbauth/couchdb.ts
+++ b/src/dbauth/couchdb.ts
@@ -1,6 +1,11 @@
 'use strict';
 import { DocumentScope, ServerScope } from 'nano';
-import { getSecurityDoc, putSecurityDoc, toArray } from '../util';
+import {
+  getSecurityDoc,
+  hyphenizeUUID,
+  putSecurityDoc,
+  toArray
+} from '../util';
 import { hashCouchPassword, Hashing } from '../hashing';
 import { Config } from '../types/config';
 import { CouchDbAuthDoc } from '../types/typings';
@@ -46,7 +51,7 @@ export class CouchAdapter implements DBAdapter {
       _id: userPrefix + key,
       type: 'user',
       name: key,
-      user_uid: user_uid,
+      user_uid: hyphenizeUUID(user_uid),
       user_id: username,
       expires: expires,
       roles: roles,

--- a/src/dbauth/couchdb.ts
+++ b/src/dbauth/couchdb.ts
@@ -28,6 +28,7 @@ export class CouchAdapter implements DBAdapter {
    */
   async storeKey(
     username: string,
+    user_uid,
     key: string,
     password: string,
     expires: number,
@@ -45,6 +46,7 @@ export class CouchAdapter implements DBAdapter {
       _id: userPrefix + key,
       type: 'user',
       name: key,
+      user_uid: user_uid,
       user_id: username,
       expires: expires,
       roles: roles,

--- a/src/dbauth/couchdb.ts
+++ b/src/dbauth/couchdb.ts
@@ -28,7 +28,7 @@ export class CouchAdapter implements DBAdapter {
    */
   async storeKey(
     username: string,
-    user_uid,
+    user_uid: string,
     key: string,
     password: string,
     expires: number,

--- a/src/dbauth/index.ts
+++ b/src/dbauth/index.ts
@@ -26,6 +26,7 @@ export class DBAuth {
 
   storeKey(
     username: string,
+    user_uid,
     key: string,
     password: string,
     expires: number,
@@ -34,6 +35,7 @@ export class DBAuth {
   ) {
     return this.adapter.storeKey(
       username,
+      user_uid,
       key,
       password,
       expires,

--- a/src/dbauth/index.ts
+++ b/src/dbauth/index.ts
@@ -26,7 +26,7 @@ export class DBAuth {
 
   storeKey(
     username: string,
-    user_uid,
+    user_uid: string,
     key: string,
     password: string,
     expires: number,

--- a/src/types/typings.d.ts
+++ b/src/types/typings.d.ts
@@ -23,6 +23,7 @@ export interface CouchDbAuthDoc
   extends IdentifiedDocument,
     MaybeRevisionedDocument,
     IdentifiedObj {
+  user_uid: string;
   user_id: string;
   password?: string;
   expires: number;

--- a/src/user.ts
+++ b/src/user.ts
@@ -559,6 +559,7 @@ export class User {
     token.provider = provider;
     await this.dbAuth.storeKey(
       user.key,
+      user_uid,
       token.key,
       password,
       token.expires,

--- a/src/user.ts
+++ b/src/user.ts
@@ -559,7 +559,7 @@ export class User {
     token.provider = provider;
     await this.dbAuth.storeKey(
       user.key,
-      user_uid,
+      hyphenizeUUID(user_uid),
       token.key,
       password,
       token.expires,

--- a/test/dbauth.spec.ts
+++ b/test/dbauth.spec.ts
@@ -70,6 +70,7 @@ describe('DBAuth', () => {
     /**  @type {import('../types/typings').CouchDbAuthDoc}  */
     const newKey = await dbAuth.storeKey(
       testUser._id,
+      '86801e38-e3f6-49b4-9187-e5116aa1ecea',
       'testkey',
       'testpass',
       Date.now() + 60000,

--- a/test/dbauth.spec.ts
+++ b/test/dbauth.spec.ts
@@ -236,6 +236,7 @@ describe('DBAuth', () => {
         promises.push(
           dbAuth.storeKey(
             'testuser1',
+            'testuser1uid',
             'oldkey1',
             'password',
             user1.session.oldkey1.expires,
@@ -246,6 +247,7 @@ describe('DBAuth', () => {
         promises.push(
           dbAuth.storeKey(
             'testuser1',
+            'testuser1uid',
             'goodkey1',
             'password',
             user1.session.goodkey1.expires,
@@ -256,6 +258,7 @@ describe('DBAuth', () => {
         promises.push(
           dbAuth.storeKey(
             'testuser2',
+            'testuser2uid',
             'oldkey2',
             'password',
             user2.session.oldkey2.expires,
@@ -266,6 +269,7 @@ describe('DBAuth', () => {
         promises.push(
           dbAuth.storeKey(
             'testuser2',
+            'testuser2uid',
             'goodkey2',
             'password',
             user2.session.goodkey2.expires,


### PR DESCRIPTION
This adds user_uid to the CouchDB auth doc to easily find the corresponding sl-user by the bearer token.